### PR TITLE
[PORT-12] Feat/12 projects page init

### DIFF
--- a/studio/schemas/documents/project.ts
+++ b/studio/schemas/documents/project.ts
@@ -1,0 +1,100 @@
+import { format, parseISO } from 'date-fns';
+import { BiEdit } from 'react-icons/bi';
+
+export default {
+  name: 'project',
+  title: 'Projects',
+  type: 'document',
+  icon: BiEdit,
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: 'Keep it short, catchy, and descriptive 👌🏽',
+    },
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      description:
+        'Hint: some frontends will require a slug to be set to be able to show the post',
+      readOnly: ({ parent, value }) => !value && parent?.external,
+      options: {
+        source: 'title',
+        slugify: (input) =>
+          input
+            .toLowerCase()
+            .replace(/\s+/g, '-')
+            .slice(0, 96)
+            //Remove special characters
+            .replace(/[&\/\\#,+()$~%.'":*?<>{}]/g, ''),
+        validation: (Rule) => Rule.required(),
+      },
+    },
+    {
+      name: 'external',
+      type: 'url',
+      title: 'URL',
+      description: 'Provide a URL to an externally linked post',
+      readOnly: ({ parent, value }) => !value && parent?.slug,
+    },
+    {
+      name: 'publishedAt',
+      title: 'Published at',
+      type: 'datetime',
+      description: 'Hint: this can be used to schedule post for publishing',
+    },
+    {
+      name: 'mainImage',
+      title: 'Main image',
+      type: 'mainImage',
+    },
+    {
+      name: 'summary',
+      type: 'summaryPortableText',
+      title: 'Summary',
+      description: 'Hint: enhance SEO by including a summary',
+    },
+    {
+      name: 'author',
+      title: 'Author',
+      type: 'reference',
+      to: { type: 'author' },
+    },
+    {
+      name: 'categories',
+      title: 'Categories',
+      type: 'array',
+      of: [{ type: 'reference', to: { type: 'category' } }],
+    },
+    {
+      name: 'body',
+      title: 'Body',
+      type: 'markdown',
+    },
+  ],
+
+  preview: {
+    select: {
+      title: 'title',
+      publishedAt: 'publishedAt',
+      author: 'author.name',
+      media: 'mainImage',
+    },
+    prepare({ title = 'No title', publishedAt, author, media }) {
+      const post = {
+        title,
+        media,
+        subtitle: author && `by ${author}`,
+      };
+
+      if (publishedAt) {
+        const dateSegment = format(parseISO(publishedAt), 'yyyy-MM');
+        post.subtitle = `${post.subtitle} on ${dateSegment}`;
+      }
+
+      return post;
+    },
+  },
+};

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -9,6 +9,7 @@ import author from './documents/author';
 import bodyPortableText from './objects/bodyPortableText';
 import category from './documents/category';
 import post from './documents/post';
+import project from './documents/project';
 import page from './documents/page';
 import siteSettings from './documents/siteSettings';
 import navigation from './documents/navigation';
@@ -32,6 +33,7 @@ export default createSchema({
     // in the studio.
     page,
     post,
+    project,
     category,
     author,
     siteSettings,

--- a/web/src/components/Header/HeaderNav.tsx
+++ b/web/src/components/Header/HeaderNav.tsx
@@ -8,8 +8,8 @@ import MobileMenu from './MobileMenu';
 
 const navMenu: NavLink[] = [
   { title: 'Home', url: '/' },
-  { title: 'About', url: '/about' },
-  // { title: 'Projects', url: '/projects'},
+  // { title: 'About', url: '/about' },
+  { title: 'Projects', url: '/projects' },
 ];
 
 const HeaderNav = () => {


### PR DESCRIPTION
Adds Projects schema to site and hides About page link.

Note: this is still not the correct behaviour we want to use for the navigation section, but it'll do for now.